### PR TITLE
itools: Support html5

### DIFF
--- a/itools/html/schema.py
+++ b/itools/html/schema.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import from itools
+from itools.core import proto_lazy_property
 from itools.datatypes import Boolean, Integer, Unicode, String, URI
 from itools.xml import XMLError, XMLNamespace, register_namespace
 from itools.xml import ElementSchema
@@ -55,7 +56,6 @@ html_attributes = {
     'background': URI,
     'bgcolor': String,
     'border': Integer,
-    # XXX Check, http://www.w3.org/TR/html4/index/attributes.html
     'cellpadding': String,
     'cellspacing': String,
     'char': String,
@@ -189,24 +189,37 @@ html_attributes = {
 
 
 # Predefined sets of attributes
-core_attrs = [
-    'id', 'class', 'style', 'title']
 
-i18n_attrs = [
-    'lang', 'dir']
+# https://www.w3.org/TR/html5/single-page.html#global-attributes
+global_attrs = [
+    'accesskey', 'class', 'contenteditable', 'dir', 'hidden',
+    'id', 'lang', 'spellcheck', 'style', 'tabindex', 'title',
+    'translate']
 
+# https://www.w3.org/TR/html5/single-page.html#global-attributes
 event_attrs = [
-    'onclick', 'ondblclick', 'onmousedown', 'onmouseup', 'onmouseover',
-    'onmousemove', 'onmouseout', 'onkeypress', 'onkeydown', 'onkeyup']
+    'onabort', 'onblur', 'oncancel', 'oncanplay', 'oncanplaythrough',
+    'onchange', 'onclick', 'oncuechange', 'ondblclick', 'ondurationchange',
+    'onemptied', 'onended', 'onerror', 'onfocus', 'oninput', 'oninvalid',
+    'onkeydown', 'onkeypress', 'onkeyup', 'onload', 'onloadeddata',
+    'onloadedmetadata', 'onloadstart', 'onmousedown', 'onmouseenter',
+    'onmouseleave', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup',
+    'onmousewheel', 'onpause', 'onplay', 'onplaying', 'onprogress', 'onratechange',
+    'onreset', 'onresize', 'onscroll', 'onseeked', 'onseeking', 'onselect',
+    'onshow', 'onstalled', 'onsubmit', 'onsuspend', 'ontimeupdate', 'ontoggle',
+    'onvolumechange', 'onwaiting',]
 
-focus_attrs = [
-    'accesskey', 'tabindex', 'onfocus', 'onblur']
+# https://www.w3.org/TR/html5/single-page.html#custom-data-attribute
+custom_attr = []
 
-common_attrs = core_attrs + i18n_attrs + event_attrs
+aria_attrs = ['aria-atomic', 'aria-busy', 'aria-controls', 'aria-describedby',
+              'aria-disabled', 'aria-dropeffect', 'aria-flowto', 'aria-grabbed',
+              'aria-haspopup', 'aria-hidden', 'aria-invalid', 'aria-label',
+              'aria-labelledby', 'aria-live', 'aria-owns', 'aria-relevant',
+              'aria-expanded', 'aria-valuemin', 'aria-valuemax', 'aria-valuenow',
+              'role']
 
-cellhalign_attrs = ['align', 'char', 'charoff']
-
-cellvalign_attrs = ['valign']
+common_attrs = global_attrs + event_attrs + custom_attr + aria_attrs
 
 
 
@@ -219,23 +232,31 @@ html_uri = 'http://www.w3.org/1999/xhtml'
 class Element(ElementSchema):
 
     # Default
+    strict = True
     is_empty = False
     is_inline = True
+    attributes = []
+    obsolete_attributes = []
+    free_attributes = html_attributes
 
-
-    def __init__(self, name, attributes, **kw):
-        # By default: context = name of element
-        self.context = '%s' % name
-
-        ElementSchema.__init__(self, name, **kw)
-        self.attributes = frozenset(attributes)
-
-
-    def get_attr_datatype(self, name, attributes):
-        if name not in self.attributes:
-            message = 'unexpected "%s" attribute for "%s" element'
-            raise XMLError, message % (name, self.name)
-        return html_attributes[name]
+    def get_attr_datatype(self, name, attr_attributes):
+        attributes = common_attrs + self.attributes + self.obsolete_attributes
+        if name not in attributes and not name.startswith(('data-', 'ng-')):
+            if self.strict:
+                message = 'unexpected "{}" attribute for "{}" element'
+                raise XMLError(message.format(name, self.name))
+            else:
+                msg = "WARNING HTML5: {} isn't an attribute for element {}"
+                print(msg.format(name, self.name))
+                return String
+        if name in self.obsolete_attributes:
+            msg = 'WARNING HTML5: {} is an obsolete attribute for element {}'
+            print(msg.format(name, self.name))
+        # Configured datatype
+        if self.free_attributes.get(name, None):
+            return self.free_attributes.get(name)
+        # Proxy
+        return String
 
 
 
@@ -271,166 +292,386 @@ class InputElement(Element):
             if (attributes.get(key1) == 'submit' or
                 attributes.get(key2) == 'submit'):
                 return Unicode(context='button')
+        proxy = super(InputElement, self)
+        return proxy.get_attr_datatype(attr_name, attributes)
 
-        return Element.get_attr_datatype(self, attr_name, attributes)
 
+
+class WebComponentElement(BlockElement):
+
+    def get_attr_datatype(self, attr_name, attributes):
+        return String
 
 ###########################################################################
 # Namespace
 ###########################################################################
+obsolete_html_elements = [
+    Element(name='applet', obsolete_attributes=['datasrc', 'datafld']),
+    Element(name='acronym'),
+    Element(name='bgsound'),
+    Element(name='dir'),
+    EmptyBlockElement(
+        name='frame',
+        attributes=['longdesc', 'name', 'src',
+          'frameborder', 'marginwidth', 'marginheight', 'noresize',
+          'scrolling'],
+        obsolete_attributes=['datasrc', 'datafld']),
+    BlockElement(name='frameset', attributes=['rows', 'cols', 'onload',
+        'onunload']),
+    BlockElement(name='noframes'),
+    BlockElement(name='hgroup'),
+    BlockElement(name='isindex', attributes=['prompt']),
+    BlockElement(name='listing', attributes=['prompt']),
+    BlockElement(name='nextid', attributes=['prompt']),
+    BlockElement(name='noembed', attributes=['prompt']),
+    BlockElement(name='plaintext', attributes=['prompt']),
+    Element(name='strike'),
+    Element(name='xmp'),
+    EmptyElement(name='basefont', attributes=['id', 'size', 'color', 'face']),
+    EmptyElement(name='big', attributes=['id', 'size', 'color', 'face']),
+    EmptyElement(name='blink', attributes=['id', 'size', 'color', 'face']),
+    BlockElement(name='center'),
+    Element(name='font', attributes=['size', 'color', 'face']),
+    Element(
+        name='marquee',
+        attributes=['size', 'color', 'face'],
+        obsolete_attributes=['datasrc', 'datafld', 'dataformatas']),
+    Element(name='multicol', attributes=['size', 'color', 'face']),
+    Element(name='nobr', attributes=['size', 'color', 'face']),
+    Element(name='spacer', attributes=['size', 'color', 'face']),
+    Element(name='tt'),
+]
+
+# FIXME This is a lie, <select> elements *are* inline
+# TODO Do not use the inline/block for i18n, define instead another
+# variable for this purpose.
 
 html_elements = [
-    # XHTML 1.0 strict
-    Element('a', common_attrs + ['charset', 'type', 'name', 'href',
-        'hreflang', 'rel', 'rev', 'accesskey', 'shape', 'coords', 'tabindex',
-        'target', 'onfocus', 'onblur', 'mp', 'm4a', 'm4v', 'oga', 'ogg', 'ogv',
-        'index', 'poster', 'webmv'], context='link'),
-    Element('abbr', common_attrs),
-    Element('acronym', common_attrs),
-    BlockElement('address', common_attrs),
-    EmptyBlockElement('area', common_attrs + ['shape', 'coords', 'href',
-        'nohref', 'alt', 'tabindex', 'accesskey', 'onfocus', 'onblur']),
-    Element('b', common_attrs),
-    EmptyBlockElement('base', ['href']),
-    Element('bdo', common_attrs),
-    Element('big', common_attrs),
-    BlockElement('blockquote', common_attrs + ['cite']),
-    BlockElement('body', common_attrs + ['onload', 'onunload']),
-    EmptyElement('br', core_attrs),
-    Element('button', common_attrs + focus_attrs + ['name', 'value', 'type',
-        'disabled']),
-    BlockElement('caption', common_attrs),
-    Element('cite', common_attrs),
-    Element('code', common_attrs),
-    EmptyBlockElement('col', common_attrs + cellhalign_attrs +
-        cellvalign_attrs + ['span', 'width']),
-    Element('dfn', common_attrs),
-    BlockElement('dd', common_attrs),
-    BlockElement('div', common_attrs + ['align', 'index']),
-    BlockElement('dl', common_attrs + ['compact']),
-    BlockElement('dt', common_attrs),
-    Element('em', common_attrs, context="emphasis"),
-    BlockElement('fieldset', common_attrs),
-    BlockElement('form', common_attrs + ['action', 'method', 'enctype',
-        'onsubmit', 'onreset', 'accept', 'accept-charset', 'name', 'target']),
-    BlockElement('h1', common_attrs + ['align'], context='heading'),
-    BlockElement('h2', common_attrs + ['align'], context='heading'),
-    BlockElement('h3', common_attrs + ['align'], context='heading'),
-    BlockElement('h4', common_attrs + ['align'], context='heading'),
-    BlockElement('h5', common_attrs + ['align'], context='heading'),
-    BlockElement('h6', common_attrs + ['align'], context='heading'),
-    BlockElement('head', i18n_attrs + ['profile']),
-    EmptyBlockElement('hr', common_attrs + ['align', 'noshade', 'size',
-        'width']),
-    BlockElement('html', i18n_attrs),
-    Element('i', common_attrs),
-    EmptyElement('img', common_attrs + ['src', 'alt', 'longdesc', 'height',
-        'width', 'usemap', 'ismap', 'name', 'align', 'border', 'hspace',
-        'vspace']),
-    InputElement('input', common_attrs + focus_attrs + ['type', 'name',
-        'value', 'checked', 'disabled', 'readonly', 'size', 'maxlength',
-        'src', 'alt', 'usemap', 'onselect', 'onchange', 'accept', 'align',
-        'autocomplete']),
-    Element('ins', common_attrs),
-    Element('kbd', common_attrs),
-    Element('label', common_attrs + ['for', 'accesskey', 'onfocus',
-                                     'onblur']),
-    BlockElement('legend', common_attrs + ['accesskey', 'align']),
-    BlockElement('li', common_attrs + ['type', 'value']),
-    EmptyElement('link', common_attrs + ['charset', 'href', 'hreflang',
-        'type', 'rel', 'rev', 'media']),
-    BlockElement('map', i18n_attrs + event_attrs + ['id', 'class', 'style',
-        'title', 'name']),
-    EmptyElement('meta', i18n_attrs + ['http-equiv', 'name', 'content',
-        'scheme']),
-    BlockElement('object', common_attrs + ['declare', 'classid', 'codebase',
-        'data', 'type', 'codetype', 'archive', 'standby', 'height', 'width',
-        'usemap', 'name', 'tabindex', 'align', 'border', 'hspace', 'vspace']),
-    BlockElement('ol', common_attrs + ['type', 'compact', 'start']),
-    BlockElement('optgroup', common_attrs + ['disabled', 'label']),
-    BlockElement('option', common_attrs + ['selected', 'disabled', 'label',
-        'value']),
-    BlockElement('p', common_attrs, context='paragraph'),
-    EmptyElement('param', ['id', 'name', 'value', 'valuetype', 'type']),
-    BlockElement('pre', common_attrs, keep_spaces=True),
-    Element('q', common_attrs + ['cite']),
-    Element('samp', common_attrs),
-    BlockElement('script', ['id', 'charset', 'type', 'language', 'src',
-        'defer'], skip_content=True),
-    BlockElement('noscript', ['id']),
-    # FIXME This is a lie, <select> elements *are* inline
-    # TODO Do not use the inline/block for i18n, define instead another
-    # variable for this purpose.
-    BlockElement('select', common_attrs + ['name', 'size', 'multiple',
-        'disabled', 'tabindex', 'onfocus', 'onblur', 'onchange']),
-    Element('small', common_attrs),
-    Element('span', common_attrs),
-    Element('strong', common_attrs, context="emphasis"),
-    Element('sub', common_attrs),
-    Element('sup', common_attrs),
-    BlockElement('style', i18n_attrs + ['type', 'media', 'title'],
+    Element(
+      name='a',
+      attributes=['href', 'target', 'download', 'rel', 'hreflang', 'type'],
+      obsolete_attributes=['charset', 'coords', 'shape', 'methods', 'name',
+                           'urn', 'datasrc', 'datafld'],
+      context='link'),
+    Element(name='abbr'),
+    BlockElement(name='address'),
+    EmptyBlockElement(
+        name='area',
+        attributes=['alt', 'coords', 'shape', 'href', 'target', 'download',
+                    'rel', 'hreflang', 'type'],
+        obsolete_attributes=['nohref']),
+    BlockElement(name='article'),
+    BlockElement(name='aside'),
+    BlockElement(
+        name='audio',
+        attributes=['src', 'crossorigin', 'preload', 'autoplay', 'mediagroup',
+                    'loop', 'muted', 'controls']),
+    Element(name='b'),
+    EmptyBlockElement(
+        name='base',
+        attributes=['href', 'target']),
+    Element(name='bdi'),
+    Element(name='bdo'),
+    BlockElement(name='blockquote', attributes=['cite']),
+    BlockElement(
+        name='body',
+        attributes=['onafterprint', 'onbeforeprint', 'onbeforeunload',
+                    'onhashchange', 'onmessage', 'onoffline', 'ononline',
+                    'onpagehide', 'onpageshow', 'onpopstate', 'onstorage',
+                    'onunload'],
+        obsolete_attributes=['alink', 'bgcolor', 'link', 'marginbottom',
+              'marginheight', 'marginleft', 'marginright', 'margintop',
+              'marginwidth', 'text', 'vlink', 'background']),
+    EmptyElement(
+        name='br',
+        obsolete_attributes=['clear']),
+    Element(
+        name='button',
+        attributes=['autofocus', 'disabled', 'form', 'formaction',
+                    'formenctype' , 'formmethod', 'formonvalidate',
+                    'formtarget', 'name', 'type', 'value'],
+        obsolete_attributes=['datasrc', 'datafld', 'dataformatas']),
+    EmptyBlockElement(name='canvas', attributes=['width', 'height']),
+    BlockElement(
+        name='caption',
+        obsolete_attributes=['align']),
+    Element(name='cite'),
+    Element(name='code'),
+    EmptyBlockElement(
+        name='col',
+        attributes=['span'],
+        obsolete_attributes=['align', 'char', 'charoff', 'valign', 'width']),
+    BlockElement(
+        name='colgroup',
+        attributes=['span'],
+        obsolete_attributes=['width']),
+    BlockElement(name='data', attributes=['value']),
+    BlockElement(name='datalist'),
+    BlockElement(name='dd'),
+    BlockElement(name='del', attributes=['cite', 'datetime']),
+    BlockElement(name='dfn'),
+    BlockElement(
+        name='div',
+        obsolete_attributes=['datasrc', 'datafld', 'dataformatas', 'align',
+                             'valign']),
+    BlockElement(
+        name='dl',
+        obsolete_attributes=['compact']),
+    BlockElement(name='dt'),
+    Element(name='em', context="emphasis"),
+    EmptyBlockElement(
+      name='embed',
+      attributes=['src', 'type', 'width', 'height', 'any* XXX '],
+      obsolete_attributes=['name', 'align', 'hspace', 'vspace',]),
+    BlockElement(
+        name='fieldset',
+        attributes=['disabled', 'form', 'name'],
+        obsolete_attributes=['datafld']),
+    BlockElement(name='figcaption'),
+    BlockElement(name='figure'),
+    BlockElement(name='footer'),
+    BlockElement(
+        name='form',
+        attributes=['accept-charset', 'action', 'autocomplete', 'enctype',
+                    'method', 'name', 'novalidate', 'target'],
+        obsolete_attributes=['accept']),
+    BlockElement(name='h1', obsolete_attributes=['align'], context='heading'),
+    BlockElement(name='h2', obsolete_attributes=['align'], context='heading'),
+    BlockElement(name='h3', obsolete_attributes=['align'], context='heading'),
+    BlockElement(name='h4', obsolete_attributes=['align'], context='heading'),
+    BlockElement(name='h5', obsolete_attributes=['align'], context='heading'),
+    BlockElement(name='h6', obsolete_attributes=['align'], context='heading'),
+    BlockElement(name='head', obsolete_attributes=['profile']),
+    BlockElement(name='header'),
+    EmptyBlockElement(
+        name='hr',
+        obsolete_attributes=['align', 'color', 'noshade', 'size', 'width']),
+    BlockElement(
+          name='html',
+          attributes=['manifest'],
+          obsolete_attributes=['version']),
+    Element(name='i'),
+    BlockElement(
+        name='iframe',
+        attributes=['src', 'srcdoc', 'name', 'sandbox', 'width', 'height'],
+        obsolete_attributes=['datasrc', 'datafld', 'align', 'allowtransparency',
+                            'frameborder', 'hspace', 'marginheight',
+                            'marginwidth', 'scrolling', 'vspace']),
+    EmptyElement(
+        name='img',
+        attributes=['src', 'alt', 'crossorigin', 'usemap', 'ismap', 'width',
+                    'height'],
+        obsolete_attributes=['name', 'lowsrc', 'datasrc', 'datafld', 'align',
+                             'border', 'hspace', 'vspace']),
+    InputElement(
+        name='input',
+        attributes=[
+        'accept', 'alt', 'autocomplete', 'autofocus', 'checked', 'dirname',
+        'disabled', 'form', 'formaction', 'formenctype', 'formmethod',
+        'formnovalidate', 'formtarget',
+        'height', 'list', 'max', 'maxlength', 'min', 'minlength', 'multiple',
+        'name', 'pattern', 'placeholder', 'readonly', 'required', 'size',
+        'src', 'step', 'type', 'value', 'width'],
+        obsolete_attributes=['ismap', 'usemap', 'datasrc', 'datafld',
+          'dataformatas', 'align', 'hspace', 'vspace']),
+    Element(name='ins', attributes=['cite', 'datetime']),
+    Element(name='kbd'),
+    Element(name='keygen', attributes=['autofocus', 'challenge', 'disabled',
+                                       'form', 'keytype', 'name']),
+    Element(
+        name='label',
+        attributes=['form', 'for'],
+        obsolete_attributes=['datasrc', 'datafld', 'dataformatas']),
+    BlockElement(
+        name='legend',
+        obsolete_attributes=['datasrc', 'datafld', 'dataformatas', 'align']),
+    BlockElement(
+        name='li',
+        attributes=['value'],
+        obsolete_attributes=['type']),
+    EmptyElement(
+        name='link',
+        attributes=['href', 'crossorigin', 'rel', 'media', 'hreflang', 'type',
+                    'sizes'],
+        obsolete_attributes=['charset', 'methods', 'urn', 'target']),
+    BlockElement(name='main'),
+    BlockElement(name='map', attributes=['name']),
+    EmptyElement(name='mark'),
+    EmptyElement(
+          name='meta',
+          attributes=['http-equiv', 'name', 'content', 'scheme'],
+          obsolete_attributes=['scheme']),
+    BlockElement(
+          name='meter',
+          attributes=['value', 'min', 'max', 'low', 'high', 'optimum']),
+    BlockElement(name='nav'),
+    BlockElement(name='noscript'),
+    BlockElement(
+        name='object',
+        attributes=['data', 'type', 'typemustmatch', 'name',
+                    'usemap', 'form', 'width', 'height'],
+        obsolete_attributes=['archive', 'classid', 'code', 'codebase',
+                        'codetype', 'declare', 'standby', 'datasrc', 'datafld',
+                        'dataformatas', 'align', 'border', 'hspace', 'vspace']),
+    BlockElement(
+        name='ol',
+        attributes=['reversed', 'start', 'type'],
+        obsolete_attributes=['compact']),
+    BlockElement(name='optgroup', attributes=['disabled', 'label']),
+    BlockElement(
+        name='option',
+        attributes=['selected', 'disabled', 'label', 'value'],
+        obsolete_attributes=['name', 'datasrc', 'datafld', 'dataformatas']),
+    BlockElement(name='output', attributes=['for', 'form', 'name']),
+    BlockElement(
+          name='p',
+          context='paragraph',
+          obsolete_attributes=['align']),
+    EmptyElement(
+        name='param',
+        attributes=['name', 'value'],
+        obsolete_attributes=['type', 'valuetype']),
+    BlockElement(
+        name='pre',
+        keep_spaces=True,
+        obsolete_attributes=['width']),
+    BlockElement(name='progress', attributes=['value', 'max']),
+    Element(name='q', attributes=['cite']),
+    Element(name='rb'),
+    Element(name='rp'),
+    Element(name='rt'),
+    Element(name='rtc'),
+    Element(name='ruby'),
+    Element(name='s'),
+    Element(name='samp'),
+    BlockElement(
+        name='script',
+        attributes=['src', 'charset', 'type', 'async', 'defer', 'crossorigin'],
+        obsolete_attributes=['language', 'event', 'for'],
         skip_content=True),
-    BlockElement('table', common_attrs + ['summary', 'width', 'border',
-        'frame', 'rules', 'cellspacing', 'cellpadding', 'align', 'bgcolor']),
-    BlockElement('td', common_attrs + cellhalign_attrs + cellvalign_attrs +
-        ['abbr', 'axis', 'headers', 'scope', 'rowspan', 'colspan', 'nowrap',
-         'bgcolor', 'width', 'height'], context='table cell'),
-    Element('textarea', common_attrs + ['name', 'rows', 'cols', 'disabled',
-        'readonly', 'tabindex', 'accesskey', 'onfocus', 'onblur', 'onselect',
-        'onchange', 'wrap']),
-    BlockElement('th', common_attrs + cellhalign_attrs + cellvalign_attrs +
-        ['abbr', 'axis', 'headers', 'scope', 'rowspan', 'colspan', 'nowrap',
-         'bgcolor', 'width', 'height'], context='table cell'),
-    BlockElement('colgroup', common_attrs + cellhalign_attrs +
-                             cellvalign_attrs + ['span', 'width']),
-    BlockElement('tbody', common_attrs + cellhalign_attrs + cellvalign_attrs),
-    BlockElement('tfoot', common_attrs + cellhalign_attrs + cellvalign_attrs),
-    BlockElement('thead', common_attrs + cellhalign_attrs + cellvalign_attrs),
-    BlockElement('title', i18n_attrs),
-    BlockElement('tr', common_attrs + cellhalign_attrs + cellvalign_attrs),
-    Element('tt', common_attrs),
-    BlockElement('ul', common_attrs + ['type', 'compact']),
-    Element('var', common_attrs),
-    # XHTML 1.0 transitional
-    EmptyElement('basefont', ['id', 'size', 'color', 'face']),
-    BlockElement('center', core_attrs),
-    Element('font', core_attrs + i18n_attrs + ['size', 'color', 'face']),
-    EmptyBlockElement('isindex', core_attrs + i18n_attrs + ['prompt']),
-    Element('s', common_attrs),
-    Element('strike', common_attrs),
-    Element('u', common_attrs),
-    # XHTML 1.0 frameset
-    EmptyBlockElement('frame', core_attrs + ['longdesc', 'name', 'src',
-        'frameborder', 'marginwidth', 'marginheight', 'noresize',
-        'scrolling']),
-    BlockElement('frameset', core_attrs + ['rows', 'cols', 'onload',
-        'onunload']),
-    BlockElement('iframe', core_attrs + ['longdesc', 'name', 'src',
-        'frameborder', 'marginwidth', 'marginheight', 'scrolling', 'align',
-        'height', 'width']),
-    BlockElement('noframes', common_attrs),
-    # HTML 5
-    # TODO Complete and check against an official description or schema (there
-    # is not a DTD in HTML5)
-    EmptyBlockElement('canvas', common_attrs + ['width', 'height']),
-    EmptyBlockElement('source', common_attrs + ['src', 'type']),
-    BlockElement('video', common_attrs + ['controls', 'src', 'height',
-        'width']),
-    # Vendor specific, not approved by W3C
-    # for a talk about <embed> see:
-    #   http://alistapart.com/articles/byebyeembed
-    # FIXME Check the attribute list for <embed>
-    EmptyBlockElement('embed', ['quality', 'pluginspage', 'src', 'type',
-        'autoplay', 'width', 'height']),
+    Element(name='section'),
+    BlockElement(
+        name='select',
+        attributes=['autofocus', 'disabled', 'form', 'multiple', 'name',
+                    'required', 'size'],
+        obsolete_attributes=['datasrc', 'datafld', 'dataformatas']),
+    Element(name='small'),
+    EmptyBlockElement(name='source', attributes=['src', 'type', 'media']),
+    Element(
+        name='span',
+        obsolete_attributes=['datasrc', 'datafld', 'dataformatas']),
+    Element(name='strong', context="emphasis"),
+    BlockElement(name='style', attributes=['media', 'type'], skip_content=True),
+    Element(name='sub'),
+    Element(name='sup'),
+    BlockElement(
+        name='table',
+        attributes=['border'],
+        obsolete_attributes=['datapagesize', 'summary', 'datasrc', 'datafld',
+                        'dataformatas', 'align', 'bgcolor', 'bordercolor',
+                        'cellpadding', 'cellspacing', 'frame', 'rules',
+                        'width', 'background']),
+    BlockElement(
+        name='tbody',
+        obsolete_attributes=['align', 'char', 'charoff',
+                             'valign', 'background']),
+    BlockElement(
+        name='td',
+        attributes=['colspan', 'rowspan', 'headers'],
+        obsolete_attributes=['axis', 'scope', 'align', 'bgcolor', 'char',
+                             'charoff', 'height', 'nowrap',
+                             'valign', 'width', 'background'],
+        context='table cell'),
+    BlockElement(name='template'),
+    Element(
+          name='textarea',
+          attributes=['autofocus', 'cols', 'dirname', 'disabled', 'form',
+                      'maxlength', 'minlength', 'name',
+                      'placeholder', 'readonly', 'required', 'rows', 'wrap',],
+          obsolete_attributes=['datasrc', 'datafld']),
+    BlockElement(
+        name='tfoot',
+        obsolete_attributes=['align', 'char', 'charoff', 'valign', 'background']),
+    BlockElement(
+          name='th',
+          attributes=['colspan', 'rowspan', 'headers', 'scope', 'abbr'],
+          obsolete_attributes=['axis', 'align', 'bgcolor', 'char', 'charoff',
+                               'height', 'nowrap', 'valign', 'width',
+                               'background'],
+          context='table cell'),
+    BlockElement(
+        name='thead',
+        obsolete_attributes=['align', 'char', 'charoff', 'valign', 'background']),
+    BlockElement(name='time', attributs=['datetime']),
+    BlockElement(name='title'),
+    BlockElement(
+          name='tr',
+          obsolete_attributes=['align', 'bgcolor', 'char', 'charoff', 'valign', 'background']),
+    BlockElement(
+          name='track',
+          attributes=['default', 'kind', 'label', 'src', 'srclang']),
+    BlockElement(name='u'),
+    BlockElement(
+        name='ul',
+        obsolete_attributes=['compact', 'type']
+        ),
+    Element(name='var'),
+    BlockElement(
+        name='video',
+        attributes=['src', 'crossorigin', 'poster',
+                    'preload', 'autoplay', 'mediagroup', 'loop', 'muted',
+                    'controls', 'width', 'height']),
+    BlockElement(name='wbr'),
     ]
 
 
 
-html_namespace = XMLNamespace(html_uri, None, html_elements)
+class HTML5Namespace(XMLNamespace):
+
+    uri = html_uri
+    prefix = None
+    elements = html_elements
+    obsolete_elements = obsolete_html_elements
+    attributes = html_attributes
+    strict = True
+
+    @proto_lazy_property
+    def obsolete_elements_kw(self):
+        kw = {}
+        for element in self.obsolete_elements:
+            name = element.name
+            if name in self.elements:
+                raise ValueError('element "%s" is defined twice' % name)
+            kw[name] = element
+        return kw
 
 
+    def get_element_schema(self, name):
+        element = self.elements_kw.get(name)
+        if element is not None:
+            context = element.context or name
+            return element(strict=self.strict, context=context)
+        # Obsolete elements
+        obsolete_element = self.obsolete_elements_kw.get(name)
+        if obsolete_element is not None:
+            if self.strict:
+                message = 'unexpected element "{}"'
+                raise XMLError(message.format(name))
+            msg = 'WARNING HTML5: {} is an obsolete element'
+            print(msg.format(name))
+            context = obsolete_element.context or name
+            return obsolete_element(strict=self.strict, context=context)
+        # Custom elements are authorized if contains "-"
+        # https://www.w3.org/TR/html5/infrastructure.html#extensibility-0
+        # <itools-users></itools-users>
+        if '-' in name:
+            return WebComponentElement(
+                  name=name, strict=self.strict, context=name)
+        raise XMLError('unexpected element "%s"' % name)
+
+
+html_namespace = HTML5Namespace(strict=False)
 ###########################################################################
 # Register
 ###########################################################################
 register_namespace(html_namespace)
-

--- a/itools/odf/schema.py
+++ b/itools/odf/schema.py
@@ -17,14 +17,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Import from the Standard Library
-from copy import copy
+from copy import deepcopy
 
 # Import from itools
 from itools.core import get_abspath
 from itools.datatypes import String
 from itools.handlers import ro_database
 from itools.relaxng import RelaxNGFile
-from itools.xml import register_namespace, has_namespace, XMLNamespace
+from itools.xml import register_namespace, get_namespace, XMLNamespace
 
 
 ###########################################################################
@@ -41,194 +41,180 @@ style_uri = 'urn:oasis:names:tc:opendocument:xmlns:style:1.0'
 svg_uri = 'urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0'
 text_uri = 'urn:oasis:names:tc:opendocument:xmlns:text:1.0'
 
-inline_elements = [
-    (text_uri, 'page-count'),
-    (text_uri, 'page-number'),
 
-    (text_uri, 'a'),
-    (text_uri, 'line-break'),
-    (text_uri, 'ruby-base'),
-    (text_uri, 's'),
-    (text_uri, 'span'),
-    (text_uri, 'tab'),
+class ODFRelaxNGFile(RelaxNGFile):
 
-    (text_uri, 'bibliography-mark'),
-    (text_uri, 'user-field-get'),
-    (text_uri, 'reference-ref'),
-    ]
+    inline_elements = [
+        (text_uri, 'page-count'),
+        (text_uri, 'page-number'),
 
+        (text_uri, 'a'),
+        (text_uri, 'line-break'),
+        (text_uri, 'ruby-base'),
+        (text_uri, 's'),
+        (text_uri, 'span'),
+        (text_uri, 'tab'),
 
-skip_content_elements = [
-    # Config
-    (config_uri, 'config-item'),
-
-    # Form
-    (form_uri, 'item'),
-    (form_uri, 'option'),
-
-    # Meta
-    (meta_uri, 'creation-date'),
-    (meta_uri, 'date-string'),
-    (meta_uri, 'editing-cycles'),
-    (meta_uri, 'editing-duration'),
-    (meta_uri, 'generator'),
-    (meta_uri, 'initial-creator'),
-    #(meta_uri, 'keyword'),
-    (meta_uri, 'printed-by'),
-    (meta_uri, 'print-date'),
-    (meta_uri, 'user-defined'),
-
-    # Number
-    (number_uri, 'currency-symbol'),
-    (number_uri, 'embedded-text'),
-    #(number_uri, 'text'),
-
-    # Office
-    (office_uri, 'binary-data'),
-
-    # Presentation
-    (presentation_uri, 'date-time-decl'),
-    #(presentation_uri, 'footer-decl'),
-    #(presentation_uri, 'header-decl'),
-
-    # Text
-    (text_uri, 'author-initials'),
-    (text_uri, 'author-name'),
-    # XXX (text_uri, 'bibliography-mark'),
-    (text_uri, 'bookmark-ref'),
-    #(text_uri, 'chapter'),
-    (text_uri, 'character-count'),
-    #(text_uri, 'conditional-text'),
-    (text_uri, 'creation-date'),
-    (text_uri, 'creation-time'),
-    (text_uri, 'creator'),
-    (text_uri, 'date'),
-    (text_uri, 'dde-connection'),
-    #(text_uri, 'description'),
-    (text_uri, 'editing-cycles'),
-    (text_uri, 'editing-duration'),
-    (text_uri, 'expression'),
-    (text_uri, 'file-name'),
-    #(text_uri, 'hidden-paragraph'),
-    #(text_uri, 'hidden-text'),
-    (text_uri, 'image-count'),
-    #(text_uri, 'index-entry-span'),
-    (text_uri, 'index-title-template'),
-    (text_uri, 'initial-creator'),
-    #(text_uri, 'keywords'),
-    (text_uri, 'linenumbering-separator'),
-    (text_uri, 'measure'),
-    (text_uri, 'modification-date'),
-    (text_uri, 'modification-time'),
-    #(text_uri, 'note-citation'),
-    #(text_uri, 'note-continuation-notice-backward'),
-    #(text_uri, 'note-continuation-notice-forward'),
-    (text_uri, 'note-ref'),
-    (text_uri, 'number'),
-    (text_uri, 'object-count'),
-    (text_uri, 'page-continuation'),
-    (text_uri, 'page-count'),
-    (text_uri, 'page-number'),
-    (text_uri, 'page-variable-get'),
-    (text_uri, 'page-variable-set'),
-    (text_uri, 'paragraph-count'),
-    #(text_uri, 'placeholder'),
-    (text_uri, 'print-date'),
-    (text_uri, 'print-time'),
-    (text_uri, 'printed-by'),
-    #(text_uri, 'reference-ref'),
-    #(text_uri, 'ruby-text'),
-    (text_uri, 'script'),
-    (text_uri, 'sender-city'),
-    (text_uri, 'sender-company'),
-    (text_uri, 'sender-country'),
-    (text_uri, 'sender-email'),
-    (text_uri, 'sender-fax'),
-    (text_uri, 'sender-firstname'),
-    (text_uri, 'sender-initials'),
-    (text_uri, 'sender-lastname'),
-    (text_uri, 'sender-phone-private'),
-    (text_uri, 'sender-phone-work'),
-    #(text_uri, 'sender-position'),
-    (text_uri, 'sender-postal-code'),
-    (text_uri, 'sender-state-or-province'),
-    (text_uri, 'sender-street'),
-    #(text_uri, 'sender-title'),
-    (text_uri, 'sequence'),
-    (text_uri, 'sequence-ref'),
-    (text_uri, 'sheet-name'),
-    #(text_uri, 'subject'),
-    (text_uri, 'table-count'),
-    (text_uri, 'table-formula'),
-    (text_uri, 'template-name'),
-    (text_uri, 'text-input'),
-    (text_uri, 'time'),
-    #(text_uri, 'title'),
-    (text_uri, 'user-defined'),
-    #(text_uri, 'user-field-get'),
-    (text_uri, 'user-field-input'),
-    (text_uri, 'variable-get'),
-    (text_uri, 'variable-input'),
-    (text_uri, 'variable-set'),
-    (text_uri, 'word-count'),
-
-    # SVG
-    #(svg_uri, 'title'),
-    #(svg_uri, 'desc')
-
-    # From translate (the only tag with elements)
-    (text_uri, 'tracked-changes'),
-    ]
+        (text_uri, 'bibliography-mark'),
+        (text_uri, 'user-field-get'),
+        (text_uri, 'reference-ref'),
+        ]
 
 
-contexts = [
-    (meta_uri, 'keyword', 'metadata'),
-    (meta_uri, 'user-defined', 'metadata'),
-    (text_uri, 'index-entry-span', 'text index'),
-    (text_uri, 'h', 'heading'),
-    (text_uri, 'p', 'paragraph'),
-    ]
+    skip_content_elements = [
+        # Config
+        (config_uri, 'config-item'),
+
+        # Form
+        (form_uri, 'item'),
+        (form_uri, 'option'),
+
+        # Meta
+        (meta_uri, 'creation-date'),
+        (meta_uri, 'date-string'),
+        (meta_uri, 'editing-cycles'),
+        (meta_uri, 'editing-duration'),
+        (meta_uri, 'generator'),
+        (meta_uri, 'initial-creator'),
+        #(meta_uri, 'keyword'),
+        (meta_uri, 'printed-by'),
+        (meta_uri, 'print-date'),
+        (meta_uri, 'user-defined'),
+
+        # Number
+        (number_uri, 'currency-symbol'),
+        (number_uri, 'embedded-text'),
+        #(number_uri, 'text'),
+
+        # Office
+        (office_uri, 'binary-data'),
+
+        # Presentation
+        (presentation_uri, 'date-time-decl'),
+        #(presentation_uri, 'footer-decl'),
+        #(presentation_uri, 'header-decl'),
+
+        # Text
+        (text_uri, 'author-initials'),
+        (text_uri, 'author-name'),
+        # XXX (text_uri, 'bibliography-mark'),
+        (text_uri, 'bookmark-ref'),
+        #(text_uri, 'chapter'),
+        (text_uri, 'character-count'),
+        #(text_uri, 'conditional-text'),
+        (text_uri, 'creation-date'),
+        (text_uri, 'creation-time'),
+        (text_uri, 'creator'),
+        (text_uri, 'date'),
+        (text_uri, 'dde-connection'),
+        #(text_uri, 'description'),
+        (text_uri, 'editing-cycles'),
+        (text_uri, 'editing-duration'),
+        (text_uri, 'expression'),
+        (text_uri, 'file-name'),
+        #(text_uri, 'hidden-paragraph'),
+        #(text_uri, 'hidden-text'),
+        (text_uri, 'image-count'),
+        #(text_uri, 'index-entry-span'),
+        (text_uri, 'index-title-template'),
+        (text_uri, 'initial-creator'),
+        #(text_uri, 'keywords'),
+        (text_uri, 'linenumbering-separator'),
+        (text_uri, 'measure'),
+        (text_uri, 'modification-date'),
+        (text_uri, 'modification-time'),
+        #(text_uri, 'note-citation'),
+        #(text_uri, 'note-continuation-notice-backward'),
+        #(text_uri, 'note-continuation-notice-forward'),
+        (text_uri, 'note-ref'),
+        (text_uri, 'number'),
+        (text_uri, 'object-count'),
+        (text_uri, 'page-continuation'),
+        (text_uri, 'page-count'),
+        (text_uri, 'page-number'),
+        (text_uri, 'page-variable-get'),
+        (text_uri, 'page-variable-set'),
+        (text_uri, 'paragraph-count'),
+        #(text_uri, 'placeholder'),
+        (text_uri, 'print-date'),
+        (text_uri, 'print-time'),
+        (text_uri, 'printed-by'),
+        #(text_uri, 'reference-ref'),
+        #(text_uri, 'ruby-text'),
+        (text_uri, 'script'),
+        (text_uri, 'sender-city'),
+        (text_uri, 'sender-company'),
+        (text_uri, 'sender-country'),
+        (text_uri, 'sender-email'),
+        (text_uri, 'sender-fax'),
+        (text_uri, 'sender-firstname'),
+        (text_uri, 'sender-initials'),
+        (text_uri, 'sender-lastname'),
+        (text_uri, 'sender-phone-private'),
+        (text_uri, 'sender-phone-work'),
+        #(text_uri, 'sender-position'),
+        (text_uri, 'sender-postal-code'),
+        (text_uri, 'sender-state-or-province'),
+        (text_uri, 'sender-street'),
+        #(text_uri, 'sender-title'),
+        (text_uri, 'sequence'),
+        (text_uri, 'sequence-ref'),
+        (text_uri, 'sheet-name'),
+        #(text_uri, 'subject'),
+        (text_uri, 'table-count'),
+        (text_uri, 'table-formula'),
+        (text_uri, 'template-name'),
+        (text_uri, 'text-input'),
+        (text_uri, 'time'),
+        #(text_uri, 'title'),
+        (text_uri, 'user-defined'),
+        #(text_uri, 'user-field-get'),
+        (text_uri, 'user-field-input'),
+        (text_uri, 'variable-get'),
+        (text_uri, 'variable-input'),
+        (text_uri, 'variable-set'),
+        (text_uri, 'word-count'),
+
+        # SVG
+        #(svg_uri, 'title'),
+        #(svg_uri, 'desc')
+
+        # From translate (the only tag with elements)
+        (text_uri, 'tracked-changes'),
+        ]
+
+
+    contexts = [
+        (meta_uri, 'keyword', 'metadata'),
+        (meta_uri, 'user-defined', 'metadata'),
+        (text_uri, 'index-entry-span', 'text index'),
+        (text_uri, 'h', 'heading'),
+        (text_uri, 'p', 'paragraph'),
+        ]
 
 
 ###########################################################################
 # Make the namespaces
 ###########################################################################
-def duplicate_ns(namespaces, first_uri, second_uri):
-    ns = copy(namespaces[first_uri])
-    ns.uri = second_uri
-    ns.prefix = None
-    namespaces[second_uri] = ns
-
 # Read the Relax NG schema
 rng_file = get_abspath('OpenDocument-v1.2-cd05-schema.rng')
-rng_file = ro_database.get_handler(rng_file, RelaxNGFile)
-namespaces = rng_file.get_namespaces()
-
-# Apply the metadata
-for uri, element_name in inline_elements:
-    element = namespaces[uri].get_element_schema(element_name)
-    element.is_inline = True
-for uri, element_name in skip_content_elements:
-    element = namespaces[uri].get_element_schema(element_name)
-    element.skip_content = True
-for uri, element_name, context in contexts:
-    element = namespaces[uri].get_element_schema(element_name)
-    element.context = context
+rng_file = ro_database.get_handler(rng_file, ODFRelaxNGFile)
+rng_file.auto_register()
 
 # The namespaces fo and svg have two names
 fo_uri_2 = 'http://www.w3.org/1999/XSL/Format'
-duplicate_ns(namespaces, fo_uri, fo_uri_2)
-svg_uri_2 = 'http://www.w3.org/2000/svg'
-duplicate_ns(namespaces, svg_uri, svg_uri_2)
+namespace_fo = get_namespace(fo_uri)
+register_namespace(namespace_fo(uri=fo_uri_2))
 
-# Register the namespaces
-for uri, namespace in namespaces.iteritems():
-    if not has_namespace(uri):
-        register_namespace(namespace)
+svg_uri_2 = 'http://www.w3.org/2000/svg'
+namespace_svg = get_namespace(svg_uri)
+register_namespace(namespace_svg(uri=svg_uri_2))
+
 
 # Specific to OpenOffice
 officeooo = XMLNamespace(
-    'http://openoffice.org/2009/office', 'officeooo', [],
-    {'rsid': String, 'paragraph-rsid': String})
-
+    uri='http://openoffice.org/2009/office',
+    prefix='officeooo',
+    elements=[],
+    free_atributes={'rsid': String, 'paragraph-rsid': String})
 register_namespace(officeooo)

--- a/itools/stl/schema.py
+++ b/itools/stl/schema.py
@@ -36,11 +36,15 @@ class STLElement(ElementSchema):
 
 
 stl_elements = [
-    STLElement('block', is_inline=False),
-    STLElement('inline', is_inline=True)]
+    STLElement(name='block', is_inline=False),
+    STLElement(name='inline', is_inline=True)]
 
 
-stl_namespace = XMLNamespace(stl_uri, 'stl', stl_elements, stl_attributes)
+stl_namespace = XMLNamespace(
+    uri=stl_uri,
+    prefix='stl',
+    elements=stl_elements,
+    attributes=stl_attributes)
 
 
 # Register

--- a/itools/xliff/schema.py
+++ b/itools/xliff/schema.py
@@ -22,47 +22,47 @@ from itools.xml import ElementSchema
 
 xliff_elements = [
     # Top Level and Header
-    ElementSchema('xliff'),
-    ElementSchema('file'),
-    ElementSchema('header'),
-    ElementSchema('skl'),
-    ElementSchema('external-file'),
-    ElementSchema('internal-file'),
-    ElementSchema('glossary'),
-    ElementSchema('reference'),
-    ElementSchema('phase-group'),
-    ElementSchema('phase'),
-    ElementSchema('tool'),  # 1.2
-    ElementSchema('note'),
+    ElementSchema(name='xliff'),
+    ElementSchema(name='file'),
+    ElementSchema(name='header'),
+    ElementSchema(name='skl'),
+    ElementSchema(name='external-file'),
+    ElementSchema(name='internal-file'),
+    ElementSchema(name='glossary'),
+    ElementSchema(name='reference'),
+    ElementSchema(name='phase-group'),
+    ElementSchema(name='phase'),
+    ElementSchema(name='tool'),  # 1.2
+    ElementSchema(name='note'),
     # Named Group
-    ElementSchema('context-group'),
-    ElementSchema('context'),
-    ElementSchema('count-group'),
-    ElementSchema('count'),
-    ElementSchema('prop-group'),
-    ElementSchema('prop'),
+    ElementSchema(name='context-group'),
+    ElementSchema(name='context'),
+    ElementSchema(name='count-group'),
+    ElementSchema(name='count'),
+    ElementSchema(name='prop-group'),
+    ElementSchema(name='prop'),
     # Structural
-    ElementSchema('body'),
-    ElementSchema('group'),
-    ElementSchema('trans-unit'),
-    ElementSchema('source'),
-    ElementSchema('target'),
-    ElementSchema('bin-unit'),
-    ElementSchema('bin-source'),
-    ElementSchema('bin-target'),
-    ElementSchema('alt-trans'),
+    ElementSchema(name='body'),
+    ElementSchema(name='group'),
+    ElementSchema(name='trans-unit'),
+    ElementSchema(name='source'),
+    ElementSchema(name='target'),
+    ElementSchema(name='bin-unit'),
+    ElementSchema(name='bin-source'),
+    ElementSchema(name='bin-target'),
+    ElementSchema(name='alt-trans'),
     # Inline
-    ElementSchema('g'),
-    ElementSchema('x'),
-    ElementSchema('bx'),
-    ElementSchema('ex'),
-    ElementSchema('bpt'),
-    ElementSchema('ept'),
-    ElementSchema('sub'),
-    ElementSchema('it'),
-    ElementSchema('ph'),
+    ElementSchema(name='g'),
+    ElementSchema(name='x'),
+    ElementSchema(name='bx'),
+    ElementSchema(name='ex'),
+    ElementSchema(name='bpt'),
+    ElementSchema(name='ept'),
+    ElementSchema(name='sub'),
+    ElementSchema(name='it'),
+    ElementSchema(name='ph'),
     # Delimiter
-    ElementSchema('mrk'),
+    ElementSchema(name='mrk'),
 ]
 
 
@@ -71,7 +71,9 @@ xliff_elements = [
 
 #'urn:oasis:names:tc:xliff:document:1.1'
 xliff_namespace = XMLNamespace(
-    'urn:oasis:names:tc:xliff:document:1.2', None, xliff_elements)
+    uri='urn:oasis:names:tc:xliff:document:1.2',
+    prefix=None,
+    elements=xliff_elements)
 
 
 ###########################################################################

--- a/itools/xml/dublin_core.py
+++ b/itools/xml/dublin_core.py
@@ -40,24 +40,24 @@ dc_attributes = {
 
 
 dc_elements = [
-    ElementSchema('creator', context='creator', skip_content=True),
-    ElementSchema('description'),
-    ElementSchema('date', skip_content=True),
-    ElementSchema('format'),
-    ElementSchema('language', skip_content=True),
-    ElementSchema('publisher'),
-    ElementSchema('rights'),
-    ElementSchema('subject'),
-    ElementSchema('title', context='title'),
-    ElementSchema('type'),
+    ElementSchema(name='creator', context='creator', skip_content=True),
+    ElementSchema(name='description'),
+    ElementSchema(name='date', skip_content=True),
+    ElementSchema(name='format'),
+    ElementSchema(name='language', skip_content=True),
+    ElementSchema(name='publisher'),
+    ElementSchema(name='rights'),
+    ElementSchema(name='subject'),
+    ElementSchema(name='title', context='title'),
+    ElementSchema(name='type'),
     ]
 
 
 dc_namespace = XMLNamespace(
-    'http://purl.org/dc/elements/1.1/', 'dc',
-    dc_elements,
-    dc_attributes)
-
+    uri='http://purl.org/dc/elements/1.1/',
+    prefix='dc',
+    elements=dc_elements,
+    attributes=dc_attributes)
 
 
 ###########################################################################


### PR DESCRIPTION
Now Schema & Element are prototypes
Move inline configuration into relaxng handler
Update html5 schema & add obsolete elements/attributes
By default the parser is not strict, so it will display warnings if we're using obsolete's things