### PR TITLE
Set access log to be apache compliant

### DIFF
--- a/itools/web/server.py
+++ b/itools/web/server.py
@@ -62,7 +62,7 @@ class WebServer(SoupServer):
     def log_access(self, host, request_line, status_code, body_length):
         if host:
             host = host.split(',', 1)[0].strip()
-        now = strftime('%d/%b/%Y:%H:%M:%S')
+        now = strftime('%d/%b/%Y:%H:%M:%S %z')
         message = '%s - - [%s] "%s" %d %d\n' % (host, now, request_line,
                                                 status_code, body_length)
         log_info(message, domain='itools.web_access')


### PR DESCRIPTION
In order to easily parse access log we need to make them apache compliant, just by adding the timezone.