### PR TITLE
Fix cases where FormError return a XMLParser not accepted by STL

### DIFF
--- a/itools/validators/exceptions.py
+++ b/itools/validators/exceptions.py
@@ -45,7 +45,7 @@ class ValidationError(Exception):
         if mode == 'html':
             msg = '<br/>'.join(messages)
             return MSG(msg, format='html')
-        return '\n'.join(messages)
+        return MSG('\n'.join(messages))
 
 
     def __str__(self):

--- a/itools/web/exceptions.py
+++ b/itools/web/exceptions.py
@@ -137,7 +137,7 @@ class FormError(StandardError):
         if mode == 'html':
             msg = '<br/>'.join(messages)
             return ERROR(msg, format='html')
-        return '\n'.join(messages)
+        return ERROR('\n'.join(messages))
 
 
     def __str__(self):

--- a/itools/web/views.py
+++ b/itools/web/views.py
@@ -212,7 +212,7 @@ class ItoolsView(prototype):
 
 
     def on_form_error_default(self, resource, context):
-        context.message = context.form_error.get_message()
+        context.message = context.form_error.get_message(mode='text')
         # Return to GET view on error
         return self.GET
 
@@ -429,7 +429,7 @@ class STLView(BaseView):
                 try:
                     value = context.get_form_value(name, type=datatype)
                 except FormError, err:
-                    error = err.get_message()
+                    error = err.get_message(mode='text')
                     if issubclass(datatype, Enumerate):
                         value = datatype.get_namespace(None)
                     else:
@@ -448,7 +448,7 @@ class STLView(BaseView):
                 try:
                     value = self.get_value(resource, context, name, datatype)
                 except FormError, err:
-                    error = err.get_message()
+                    error = err.get_message(mode='text')
                     if issubclass(datatype, Enumerate):
                         value = datatype.get_namespace(None)
                     else:


### PR DESCRIPTION
Fix this TB when an AutoField is submitted and encounter mandatory field errors

```
Traceback (most recent call last):
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/web/router.py", line 280, in handle_request
    context.site_root.after_traverse(context)
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/ikaaro/root.py", line 253, in after_traverse
    context.entity = self.get_skin(context).template(body)
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/ikaaro/skins.py", line 439, in template
    data = stl(handler, namespace, prefix=prefix, mode='html')
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/stl/stl.py", line 311, in stl
    return stream_to_str_as_html(stream, encoding)
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/html/xhtml.py", line 118, in stream_to_str_as_html
    stream = set_content_type(stream, content_type)
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/html/xhtml.py", line 81, in set_content_type
    for event in stream:
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/stl/stl.py", line 375, in process
    for event, value, kk in stream:
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/stl/stl.py", line 269, in substitute
    for x in value:
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/stl/stl.py", line 406, in process
    encoding, skip_events):
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/stl/stl.py", line 375, in process
    for event, value, kk in stream:
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/stl/stl.py", line 269, in substitute
    for x in value:
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/stl/stl.py", line 431, in process
    stack, re_stack, encoding)
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/stl/stl.py", line 359, in process_start_tag
    value, n = substitute_attribute(value, stack, repeat, encoding)
  File "/home/florian/.local/share/virtualenvs/076/lib/python2.7/site-packages/itools/stl/stl.py", line 217, in substitute_attribute
    return value.gettext().encode(encoding), 1
AttributeError: 'itools.xml.parser.XMLParser' object has no attribute 'encode'
```