### PR TITLE
Add benchmark log file and benchmark request time

### DIFF
--- a/BENCHMARK.txt
+++ b/BENCHMARK.txt
@@ -1,0 +1,112 @@
+
+Table of contents:
+
+  1. How to benchmark ?
+  2. How to analyze ?
+
+
+1. What can be benchmarked ?
+============================
+
+At every request Itools saved into a file (log/access) some infos :
+ - Request ip address
+ - Request date (HTTPDATE format)
+ - Request verb
+ - Request route
+ - Request HTTP version
+ - Request status
+ - Request processing time (in seconds with milliseconds resolution.)
+
+Generating a file containing many lines such as :
+
+localhost - - [23/Mar/2017:13:56:07 +0100] "GET / HTTP/1.1" 200 0.497
+
+
+2. How to analyze ?
+===================
+
+You can decide to analyze on the flow or after copying the file.
+
+There are many possible stack to analyze :
+
+ - Using small tools such as GOACCESS (https://goaccess.io)
+ - Using more complex stack such as the InfluxDATA TICK STACK
+
+You can use the tool you want.
+The most important think is the log format that of course can be overrided in every tool
+
+
+2.1 Using the GOACCESS tool
+----------------------------
+
+Goaccess is an open source real-time web log analyzer and interactive viewer that runs in a terminal in *nix systems or through your browser.
+
+
+In the terminal :
+$ goaccess FILE --log-format '%h %^[%d:%t %^] "%r" %s %b %T' --time-format '%H:%M:%S' --date-format '%d/%b/%Y'
+
+Generate an HTML report :
+$ goaccess FILE --log-format '%h %^[%d:%t %^] "%r" %s %b %T' --time-format '%H:%M:%S' --date-format '%d/%b/%Y' -a -o report.html
+
+
+2.2 Using the InfluxDATA TICK STACK
+------------------------------------
+
+TICK Stack is composed of 4 tools :
+
+- Telegraf (https://github.com/influxdata/telegraf)
+- InfluxDB (https://github.com/influxdata/influxdb)
+- Chronograf (https://github.com/influxdata/chonograf)
+- Kapacitor (https://github.com/influxdata/kapacitor)
+
+Only the first 2 are needed to benchmark.
+
+Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
+It will automatically read the data from the file (as an input) and save them in an output (InfluxDB).
+
+Here is a telegraf configuration file :
+
+```
+# Telegraf Configuration
+
+# Configuration for telegraf agent
+[agent]
+  ## Default data collection interval for all inputs
+  interval = "10s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "10s"
+  flush_jitter = "0s"
+
+  ## Logging configuration:
+  debug = false
+  quiet = false
+
+###############################################################################
+#                            OUTPUT PLUGINS                                   #
+###############################################################################
+
+# Configuration for influxdb server to send metrics to
+[[outputs.influxdb]]
+  urls = ["http://influxdb:8086"] # InfluxDB HTTP API
+  database = "telegraf" # Database name where to store data
+  write_consistency = "any"
+  timeout = "5s"
+
+
+###############################################################################
+#                            SERVICE INPUT PLUGINS                            #
+###############################################################################
+
+# Stream and parse log file(s).
+[[inputs.logparser]]
+  files = ["/var/log/benchmark.log"]
+  from_beginning = false
+
+  [inputs.logparser.grok]
+    patterns = ["%{IPORHOST:client_ip} %{NOTSPACE:ident} %{NOTSPACE:auth} \\[%{HTTPDATE:ts:ts-httpd}\\] \"(?:%{WORD:verb:tag} %{NOTSPACE:request}(?: HTTP/%{NUMBER:http_version:float})?|%{DATA})\" %{NUMBER:resp_code:tag} (?:%{NUMBER:loading_time:float})"]
+    ## Name of the outputted measurement name.
+    measurement = "benchmark"
+```

--- a/itools/web/context.py
+++ b/itools/web/context.py
@@ -26,6 +26,7 @@ from copy import deepcopy
 from base64 import decodestring, encodestring
 from datetime import datetime, timedelta
 from hashlib import sha224
+from time import time
 from urllib import quote, unquote
 
 # Import from pytz
@@ -636,6 +637,7 @@ class Context(prototype):
 
     def handle_request(self, soup_message, path):
         # (1) Attach to the soup message and path
+        start_time = time()  # Set start time
         context = self()
         context.soup_message = soup_message
         context.path = path
@@ -663,8 +665,10 @@ class Context(prototype):
         except StandardError:
             log_error('Internal error', domain='itools.web')
             context.set_default_response(500)
-            return context
         finally:
+            # Set request_time to the server to log in access
+            request_time = time() - start_time
+            self.server.request_time = request_time
             set_context(None)
             return context
 

--- a/itools/web/server.py
+++ b/itools/web/server.py
@@ -43,6 +43,8 @@ class WebServer(SoupServer):
     accept_cors = False
     dispatcher = URIDispatcher()
 
+    request_time = 0  # Initialized after each request (in handle_request)
+
 
     def __init__(self, root, access_log=None, event_log=None):
         super(WebServer, self).__init__()
@@ -54,7 +56,6 @@ class WebServer(SoupServer):
         # Events log
         logger = WebLogger(event_log)
         register_logger(logger, 'itools.web')
-
         # Useful the current uploads stats
         self.upload_stats = {}
 
@@ -63,8 +64,9 @@ class WebServer(SoupServer):
         if host:
             host = host.split(',', 1)[0].strip()
         now = strftime('%d/%b/%Y:%H:%M:%S %z')
-        message = '%s - - [%s] "%s" %d %d\n' % (host, now, request_line,
-                                                status_code, body_length)
+        message = '%s - - [%s] "%s" %d %d %.3f\n' % (host, now, request_line,
+                                                     status_code, body_length,
+                                                     self.request_time)
         log_info(message, domain='itools.web_access')
 
 


### PR DESCRIPTION
Add a benchmark tool to save into a file /log/benchmark time query and clock query.

## How to use ?

- Add option --benchmark when starting the server

## What is saved ?

`localhost - - [23/Mar/2017:13:56:07 +0100] "GET / HTTP/1.1" 200 0.497`

Where : 

- localhost : ip
- [23/Mar/2017:13:56:07 +0100] : Date
- GET / HTTP/1.1 : The request verb and HTTP version
- 200 : The request status 
-  0.497 : The processing time

## What to do with that ?

 - Read the BENCHMARK.txt file !

But it can produced things like :

![image](https://cloud.githubusercontent.com/assets/2914164/24559910/cc3807aa-1640-11e7-93b2-f14ada10b2aa.png)

![image](https://cloud.githubusercontent.com/assets/2914164/24559939/e4125c22-1640-11e7-849e-58bbb9b274e5.png)