### PR TITLE
Fix Allow and Access_Control_Allow_Methods usage

### DIFF
--- a/itools/web/router.py
+++ b/itools/web/router.py
@@ -303,6 +303,12 @@ class RequestMethod(object):
         if content_type:
             content_type, type_parameters = content_type
         accept_json = accept == 'application/json'
+        # Manage error code
+        if error.code == 405:
+            # Add allow methods in case of 405
+            # https://tools.ietf.org/html/rfc7231#section-6.5.5
+            known_methods = context.view.get_known_methods()
+            context.set_header('Allow', ', '.join(known_methods))
         status = error.code
         context.status = status
         is_ui = str(context.path).startswith('/ui/')

--- a/itools/web/server.py
+++ b/itools/web/server.py
@@ -170,7 +170,7 @@ class WebServer(SoupServer):
         # XXX Hardcoded
         known_methods = ['GET', 'HEAD', 'POST', 'OPTIONS', 'PUT', 'PATCH', 'DELETE']
         soup_message.set_status(200)
-        soup_message.set_header('Allow', ','.join(known_methods))
+        soup_message.set_header('Access-Control-Allow-Methods', ', '.join(known_methods))
 
 
 

--- a/itools/web/views.py
+++ b/itools/web/views.py
@@ -104,7 +104,7 @@ class ItoolsView(prototype):
     def OPTIONS(self, resource, context):
         """Return list of HTTP methods allowed"""
         known_methods = self.get_known_methods()
-        context.set_header('Allow', ','.join(known_methods))
+        context.set_header('Access-Control-Allow-Methods', ', '.join(known_methods))
         context.entity = None
         context.status = 200
 


### PR DESCRIPTION
In fact Allow header must only be used for 405 requests (and is mandatory)
In every other case Access Control Allow Methods should be used

CF https://tools.ietf.org/html/rfc7231#section-6.5.5